### PR TITLE
Add message in unit tests

### DIFF
--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -478,8 +478,8 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$attachments = $mailer->getAttachments();
 
 		$this->assertTrue( $mailer->attachmentExists(), 'There are no attachments.' );
-		$this->assertSame( $attachments[0][1], $attachments[0][2], 'The attachment name did not match.' );
-		$this->assertSame( $attachments[1][1], $attachments[1][2], 'The attachment name did not match.' );
+		$this->assertSame( $attachments[0][1], $attachments[0][2], 'The first attachment name did not match.' );
+		$this->assertSame( $attachments[1][1], $attachments[1][2], 'The second attachment name did not match.' );
 	}
 
 	/**
@@ -506,8 +506,8 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$attachments = $mailer->getAttachments();
 
 		$this->assertTrue( $mailer->attachmentExists(), 'There are no attachments.' );
-		$this->assertSame( 'alonac.jpg', $attachments[0][2], 'The attachment name did not match.' );
-		$this->assertSame( 'selffaw.jpg', $attachments[1][2], 'The attachment name did not match.' );
+		$this->assertSame( 'alonac.jpg', $attachments[0][2], 'The first attachment name did not match.' );
+		$this->assertSame( 'selffaw.jpg', $attachments[1][2], 'The second attachment name did not match.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -477,9 +477,9 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 		$attachments = $mailer->getAttachments();
 
-		$this->assertTrue( $mailer->attachmentExists() );
-		$this->assertSame( $attachments[0][1], $attachments[0][2] );
-		$this->assertSame( $attachments[1][1], $attachments[1][2] );
+		$this->assertTrue( $mailer->attachmentExists(), 'There are no attachments.' );
+		$this->assertSame( $attachments[0][1], $attachments[0][2], 'The attachment name did not match.' );
+		$this->assertSame( $attachments[1][1], $attachments[1][2], 'The attachment name did not match.' );
 	}
 
 	/**
@@ -505,9 +505,9 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 		$attachments = $mailer->getAttachments();
 
-		$this->assertTrue( $mailer->attachmentExists() );
-		$this->assertSame( 'alonac.jpg', $attachments[0][2] );
-		$this->assertSame( 'selffaw.jpg', $attachments[1][2] );
+		$this->assertTrue( $mailer->attachmentExists(), 'There are no attachments.' );
+		$this->assertSame( 'alonac.jpg', $attachments[0][2], 'The attachment name did not match.' );
+		$this->assertSame( 'selffaw.jpg', $attachments[1][2], 'The attachment name did not match.' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/28407

Props to @costdev as he raised it on [Slack channel](https://wordpress.slack.com/archives/C02RQBWTW/p1672916716558629?thread_ts=1672915643.455349&cid=C02RQBWTW) 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
