### PR TITLE
Build/Test Tools: Declare phpunit/phpunit explicitly in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"phpstan/phpstan": "2.2.5",
 		"phpstan/phpstan-phpunit": "2.0.18",
+		"phpunit/phpunit": "^9.6",
 		"yoast/phpunit-polyfills": "^1.1.0"
 	},
 	"config": {


### PR DESCRIPTION
### Problem

`composer test` and `npm run test:php` both run PHPUnit, but `phpunit/phpunit` appears
nowhere in `require-dev`. It installs only as a **transitive dependency**.

Querying `vendor/composer/installed.json` for packages requiring PHPUnit returns exactly one:

```
yoast/phpunit-polyfills => ^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0
```

Combined with `"lock": false` and CI's use of `composer update`, the version the entire PHP
test suite runs on is chosen by a transitive constraint spanning PHPUnit 4 through 9.
It currently resolves to 9.6.36.

### Why it matters

The test runner is the most load-bearing dev dependency in the project, and it is implicit.
A future `yoast/phpunit-polyfills` release that widens or narrows its PHPUnit constraint
silently changes what every contributor and every CI job runs.

### Change

Declares `phpunit/phpunit: ^9.6` — the constraint the project already relies on in practice.

### Compatibility

PHPUnit 9.6 requires `php >=7.3`, so it satisfies the full CI matrix
(`7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5` per `phpunit-tests.yml:101`). This is a range, not a pin,
so it preserves the deliberate per-PHP-version dependency resolution CI depends on.

---

_Draft proposal from a review of `composer.json` / `package.json`. Opened as a draft for discussion — not intended to merge as-is._
