### PR TITLE
Build/Test Tools: Use vendor/bin/phpunit in the composer test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,6 @@
 		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
 		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
 		"lint:errors": "@lint -n",
-		"test": [ "Composer\\Config::disableProcessTimeout", "@php ./vendor/phpunit/phpunit/phpunit" ]
+		"test": [ "Composer\\Config::disableProcessTimeout", "@php ./vendor/bin/phpunit" ]
 	}
 }


### PR DESCRIPTION
### Problem

Three call sites invoke PHPUnit, using two different paths:

| Location | Path |
|---|---|
| `composer.json` (`composer test`) | `./vendor/phpunit/phpunit/phpunit` |
| `package.json` (`npm run test:php`) | `./vendor/bin/phpunit` |
| `.github/workflows/reusable-phpunit-tests-v3.yml:257` | `./vendor/bin/phpunit` |

The composer script reaches into the package directory directly, bypassing Composer's
bin proxy. Every other call site uses `vendor/bin/phpunit`, which exists.

### Change

Aligns `composer test` with CI and with `npm run test:php`.

---

_Draft proposal from a review of `composer.json` / `package.json`. Opened as a draft for discussion — not intended to merge as-is._
