### PR TITLE
Build/Test Tools: Declare dealerdirect/phpcodesniffer-composer-installer explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
 	},
 	"require-dev": {
 		"composer/ca-bundle": "1.5.13",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
 		"squizlabs/php_codesniffer": "3.13.5",
 		"wp-coding-standards/wpcs": "~3.4.1",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",


### PR DESCRIPTION
### Problem

`dealerdirect/phpcodesniffer-composer-installer` is listed in `config.allow-plugins`,
but is not in `require-dev`. It arrives transitively via `wp-coding-standards/wpcs` and
`phpcompatibility/phpcompatibility-wp`.

That plugin is what populates the PHP_CodeSniffer `installed_paths` setting — i.e. whether
`composer lint` can resolve the `WordPress` standard at all depends on a package nobody
declared. The project already explicitly trusts it in `allow-plugins`, so the dependency
is deliberate; only the declaration is missing.

### Change

Adds the explicit `require-dev` entry so the tool that makes linting work is visible.

---

_Draft proposal from a review of `composer.json` / `package.json`. Opened as a draft for discussion — not intended to merge as-is._
