### PR TITLE
Build/Test Tools: Remove the unused check-node-version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"@wordpress/scripts": "33.0.0",
 		"autoprefixer": "10.5.3",
 		"chalk": "5.6.2",
-		"check-node-version": "4.2.1",
 		"cssnano": "7.1.9",
 		"dotenv": "17.4.2",
 		"dotenv-expand": "13.0.0",


### PR DESCRIPTION
### Problem

`check-node-version` is declared in `devDependencies`, but a grep across the entire repo —
excluding `node_modules` and `package-lock.json` — returns exactly one hit: its own
declaration line in `package.json`.

It is not referenced by any npm script, Gruntfile task, tool under `tools/`, or GitHub
Actions workflow.

### Change

Removes the dependency. `package-lock.json` will need regenerating with `npm install`;
that is intentionally left out of this draft so the dependency change is reviewable on
its own.

---

_Draft proposal from a review of `composer.json` / `package.json`. Opened as a draft for discussion — not intended to merge as-is._
