### PR TITLE
Build/Test Tools: Bound the supported Node version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"ghcrRepo": "WordPress/gutenberg/gutenberg-wp-develop-build"
 	},
 	"engines": {
-		"node": ">=20.10.0",
+		"node": ">=20.10.0 <21",
 		"npm": ">=10.2.3"
 	},
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
### Problem

The Node version a contributor may install is unbounded, while CI is pinned:

| Source | Value |
|---|---|
| `package.json` `engines.node` | `>=20.10.0` |
| `.nvmrc` | `20` |
| `.npmrc` | `engine-strict = true` |
| Every CI workflow | `node-version-file: '.nvmrc'` |

A contributor on Node 22 or 24 passes the strict engine gate and develops happily, while
all CI runs Node 20. Any newer-Node behavior difference surfaces only in CI, after push.

### Change

Bounds the range to `>=20.10.0 <21` so local and CI agree.

### This is a policy proposal, not a bug fix

With `engine-strict = true`, this **blocks installs on Node 21+**. That is the point — it
makes the mismatch a local error rather than a CI surprise — but it is a real constraint on
contributors who currently use newer Node successfully. The alternative is to widen `.nvmrc`
and the CI matrix instead. Opening as a draft specifically to get a decision on which
direction is wanted.

---

_Draft proposal from a review of `composer.json` / `package.json`. Opened as a draft for discussion — not intended to merge as-is._
