### PR TITLE
Icons: Register the default icons lazily instead of on every request

### DIFF
--- a/src/wp-includes/class-wp-icons-registry.php
+++ b/src/wp-includes/class-wp-icons-registry.php
@@ -21,6 +21,14 @@ class WP_Icons_Registry {
 	protected $registered_icons = array();
 
 	/**
+	 * Whether the default icons bundled with core have been registered yet.
+	 *
+	 * @since 7.1.0
+	 * @var bool
+	 */
+	protected $default_icons_loaded = false;
+
+	/**
 	 * Container for the main instance of the class.
 	 *
 	 * @since 7.0.0
@@ -336,6 +344,8 @@ class WP_Icons_Registry {
 	 * @return array[] Array of arrays containing the registered icon properties.
 	 */
 	public function get_registered_icons( $search = '' ) {
+		$this->load_default_icons();
+
 		$icons = array();
 
 		foreach ( $this->registered_icons as $icon ) {
@@ -362,7 +372,33 @@ class WP_Icons_Registry {
 	 * @return bool True if the icon is registered, false otherwise.
 	 */
 	public function is_registered( $icon_name ) {
+		$this->load_default_icons();
+
 		return isset( $this->registered_icons[ $icon_name ] );
+	}
+
+	/**
+	 * Registers the default icons bundled with core, once, on first use.
+	 *
+	 * The core icon manifest declares 88 icons, each with a translated label.
+	 * Registering them eagerly costs every request — including front-end
+	 * requests that never render an icon — so registration is deferred until
+	 * something actually reads the registry.
+	 *
+	 * @since 7.1.0
+	 */
+	protected function load_default_icons() {
+		if ( $this->default_icons_loaded ) {
+			return;
+		}
+
+		/*
+		 * Set before registering: _wp_register_default_icons() calls back into
+		 * this class, and this flag is what stops that from recursing.
+		 */
+		$this->default_icons_loaded = true;
+
+		_wp_register_default_icons();
 	}
 
 	/**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -816,7 +816,10 @@ add_action( 'init', '_wp_register_default_font_collections' );
 
 // Icons.
 add_action( 'init', '_wp_register_default_icon_collections', 0 );
-add_action( 'init', '_wp_register_default_icons' );
+/*
+ * The default icons themselves are registered lazily, on first read of the
+ * icons registry. See WP_Icons_Registry::load_default_icons().
+ */
 
 // Add ignoredHookedBlocks metadata attribute to the template and template part post types.
 add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes' );

--- a/src/wp-includes/icons.php
+++ b/src/wp-includes/icons.php
@@ -98,6 +98,15 @@ function _wp_register_default_icon_collections() {
  * @access private
  */
 function _wp_register_default_icons() {
+	/*
+	 * Icons can be requested before `init` now that the default icons are
+	 * registered on first read, so make sure the collection they belong to
+	 * exists rather than relying on the `init` callback having run.
+	 */
+	if ( ! WP_Icon_Collections_Registry::get_instance()->is_registered( 'core' ) ) {
+		_wp_register_default_icon_collections();
+	}
+
 	$icons_directory = ABSPATH . WPINC . '/images/icon-library/';
 	$manifest_path   = ABSPATH . WPINC . '/assets/icon-library-manifest.php';
 

--- a/tests/phpunit/tests/icons/wpIconsRegistry.php
+++ b/tests/phpunit/tests/icons/wpIconsRegistry.php
@@ -453,4 +453,108 @@ class Tests_Icons_WpIconsRegistry extends WP_UnitTestCase {
 
 		$this->assertNull( $icon['content'] );
 	}
+
+	/**
+	 * Resets the registry singleton so a test starts with the default icons
+	 * unloaded.
+	 *
+	 * Needed because tear_down() unregisters a test collection, and collection
+	 * unregistration reads the icon registry in order to drop that collection's
+	 * icons — which triggers the lazy load into the replacement instance.
+	 */
+	private function reset_registry() {
+		$reflection = new ReflectionClass( WP_Icons_Registry::class );
+		$property   = $reflection->getProperty( 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+
+		$this->registry = WP_Icons_Registry::get_instance();
+	}
+
+	/**
+	 * Reads the registered icons property directly, so that the assertion itself
+	 * does not trigger the lazy registration it is checking for.
+	 *
+	 * @return array Registered icons.
+	 */
+	private function get_registered_icons_property() {
+		$reflection = new ReflectionClass( WP_Icons_Registry::class );
+		$property   = $reflection->getProperty( 'registered_icons' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+
+		return $property->getValue( $this->registry );
+	}
+
+	/**
+	 * @ticket 00000
+	 *
+	 * @covers ::load_default_icons
+	 */
+	public function test_default_icons_are_not_registered_until_the_registry_is_read() {
+		$this->reset_registry();
+
+		$this->assertSame(
+			array(),
+			$this->get_registered_icons_property(),
+			'The default icons should not be registered before the registry is read.'
+		);
+	}
+
+	/**
+	 * @ticket 00000
+	 *
+	 * @covers ::load_default_icons
+	 */
+	public function test_default_icons_are_registered_on_first_read() {
+		$this->reset_registry();
+
+		$icon = $this->registry->get_registered_icon( 'core/arrow-left' );
+
+		$this->assertIsArray( $icon, 'A core icon should resolve without explicit registration.' );
+		$this->assertSame( 'core/arrow-left', $icon['name'] );
+		$this->assertStringStartsWith( '<svg', $icon['content'] );
+		$this->assertNotEmpty(
+			$this->get_registered_icons_property(),
+			'Reading the registry should have registered the default icons.'
+		);
+	}
+
+	/**
+	 * @ticket 00000
+	 *
+	 * @covers ::is_registered
+	 */
+	public function test_is_registered_triggers_default_icon_registration() {
+		$this->reset_registry();
+
+		$this->assertTrue( $this->registry->is_registered( 'core/arrow-left' ) );
+	}
+
+	/**
+	 * The default icons belong to the `core` collection, which is normally
+	 * registered on `init`. A lazy load can happen before that, so the collection
+	 * must be ensured at load time rather than assumed to exist.
+	 *
+	 * @ticket 00000
+	 *
+	 * @covers ::load_default_icons
+	 */
+	public function test_default_icons_load_even_if_core_collection_is_missing() {
+		$collections = WP_Icon_Collections_Registry::get_instance();
+		if ( $collections->is_registered( 'core' ) ) {
+			$collections->unregister( 'core' );
+		}
+		$this->assertFalse( $collections->is_registered( 'core' ) );
+
+		$this->reset_registry();
+
+		$icons = $this->registry->get_registered_icons();
+
+		$this->assertNotEmpty( $icons, 'Default icons should register even when the collection was not set up yet.' );
+		$this->assertTrue( $collections->is_registered( 'core' ), 'The core collection should be registered on demand.' );
+	}
 }


### PR DESCRIPTION
## What

Defers registration of the 88 core icons until something actually reads the icons registry, instead of doing it on `init` for every request.

## Why

`default-filters.php` hooked registration unconditionally:

```php
add_action( 'init', '_wp_register_default_icon_collections', 0 );
add_action( 'init', '_wp_register_default_icons' );
```

`_wp_register_default_icons()` includes a 10.5 KB manifest and registers all 88 icons through `WP_Icons_Registry::register()`, which per icon runs two `preg_match` validations, an `array_fill_keys` allocation, and a key-by-key property check. The generated manifest also calls `_x()` for every label, so **88 gettext lookups run on every request**.

None of it is used unless something reads the registry — in practice the editor, the REST API, or a rendered `core/icon` block. A front-end page view that renders no icon pays the full cost and discards it.

Measured on trunk, in a booted WordPress (PHP 8.3.2, 2000 iterations, warmed):

| Component | Cost per request |
|---|---|
| `include` manifest (88 `_x()` calls) | 0.126 ms |
| 88 `register()` calls | 0.096 ms |
| **Total** | **0.221 ms** |

## How

A `$default_icons_loaded` flag on the registry, and a `load_default_icons()` guard called from the read paths — `is_registered()` and `get_registered_icons()`. `get_registered_icon()` and `unregister()` both route through `is_registered()`, so they are covered too.

```php
protected function load_default_icons() {
	if ( $this->default_icons_loaded ) {
		return;
	}

	/*
	 * Set before registering: _wp_register_default_icons() calls back into
	 * this class, and this flag is what stops that from recursing.
	 */
	$this->default_icons_loaded = true;

	_wp_register_default_icons();
}
```

`_wp_register_default_icons()` now also ensures the `core` collection exists, because a lazy load can occur before `init` fires:

```php
if ( ! WP_Icon_Collections_Registry::get_instance()->is_registered( 'core' ) ) {
	_wp_register_default_icon_collections();
}
```

Collection registration itself stays on `init` — it registers one collection with two `__()` calls, which is not worth deferring.

## Behaviour notes

Worth reviewer attention, since these are real changes rather than pure optimisation:

- **`register()` still triggers the load**, via its existing `is_registered()` duplicate check. This is deliberate: it keeps duplicate detection semantically identical to today. The trade-off is that a plugin registering its own icon on `init` will pull in the core defaults and forfeit the saving for that site. Making `register()` use a direct `isset()` would avoid that, but would change which party gets the "already registered" notice, so I left it alone.
- **Unregistering an icon collection now triggers the load.** `WP_Icon_Collections_Registry::unregister()` enumerates registered icons to drop the ones in that collection, and that read populates the defaults first. Unavoidable — you need the full list to know what to remove.
- **`_wp_register_default_icons()` no longer runs on `init`.** Anything depending on that specific timing would be affected. It remains callable directly and is `@access private`.

## Testing

Four tests added to `tests/phpunit/tests/icons/wpIconsRegistry.php`, covering: defaults absent before a read, present after a read, `is_registered()` triggering the load, and the load working when the `core` collection has not been registered yet.

They reset the registry singleton explicitly rather than relying on `set_up()`, because the existing `tear_down()` unregisters a test collection *after* nulling the singleton — and that unregistration reads the registry, lazily populating the replacement instance. Without the explicit reset the assertions leak across tests.

**Existing suites — all green** (MySQL 8.4, PHP 8.3.2), 1868 tests total:

| Suite | Result |
|---|---|
| `tests/phpunit/tests/icons/` | OK — 107 existing + 4 new |
| `tests/phpunit/tests/blocks/` | OK (999) |
| `tests/phpunit/tests/rest-api/` | OK |
| `tests/phpunit/tests/block-supports/` | OK |

**Behaviour verified directly.** Reading `registered_icons` reflectively, so the check does not itself trigger the load:

| | after bootstrap `init` | after first read | `wp_get_icon('core/arrow-left')` |
|---|---|---|---|
| trunk | 88 icons | 88 icons | valid SVG |
| this PR | **0 icons** | 88 icons | valid SVG |

## Note for the committer

The new tests carry `@ticket 00000` placeholders — these need the real Trac ticket number before landing.

## Context

From a 7.0.4 → 7.1 RC3 benchmark comparison showing a server-side regression on both Block and Classic themes (Block `wp-total` p50 +9.88% / +10.53 ms; Classic +7.92% / +3.99 ms), with `LCP − TTFB` flat on both — i.e. PHP execution time, not front-end or database. This was one of the fixed per-request costs identified; at 0.221 ms it is roughly 43% of the Classic theme's entire `wp-before-template` regression.

An alternative approach — moving `_x()` out of the generated manifest and translating lazily at read time — was considered and rejected. The manifest is copied verbatim from `gutenberg/packages/icons/src/manifest.php` by a `Gruntfile.js` task, and those literal `_x()` calls are what the i18n tooling extracts. Turning them into plain data would silently drop all 88 strings from core's POT, and there is no icon equivalent of `block-i18n.json` / `theme-i18n.json` to declare them. Deferring the include keeps the `_x()` literals intact and avoids the problem entirely.
